### PR TITLE
Enable training

### DIFF
--- a/examples/finetune_t0.sh
+++ b/examples/finetune_t0.sh
@@ -5,10 +5,8 @@
 RANK=0
 WORLD_SIZE=1
 
-DATA_PATH="{ \
-        'input_tokens': 'tests/data/t0/ag_news_prompt_inputs_document',  \
-       'target_tokens': 'tests/data/t0/ag_news_prompt_targets_document'  \
-       }"
+DATA_PATH=tests/data/t0/ag_news_prompt_inputs_document tests/data/t0/ag_news_prompt_targets_document
+
 CHECKPOINT_PATH="./checkpoints"
 TOKENIZER_PATH=gpt2
 

--- a/finetune_t0.py
+++ b/finetune_t0.py
@@ -1,13 +1,14 @@
 """Multitask Finetuning T0"""
 
+from multiprocessing.sharedctypes import Value
 import torch
-from functools import partial
 
-from megatron import get_args, get_tokenizer, get_timers, print_rank_0, mpu
+from megatron import get_args, get_tokenizer, print_rank_0, mpu
 from megatron.data.non_causal_mtf_dataset import build_train_valid_test_datasets, build_dataset_group
-from megatron.model import GPTModel, GPTModelPipe
+from megatron.model import GPTModelPipe
 from megatron.training import pretrain
 from megatron.utils import get_ltor_masks_and_position_ids, get_packed_attention_mask
+from megatron.utils import average_losses_across_data_parallel_group
 
 import deepspeed
 from deepspeed.runtime.utils import see_memory_usage
@@ -42,15 +43,10 @@ def model_provider(pre_process=True, post_process=True):
             # We need to call model.set_batch_fn after deepspeed.initialize
             model._megatron_batch_fn = get_batch_pipe_packed
         else:
-            model = GPTModel(
-                num_tokentypes=0,
-                parallel_output=True,
-                pre_process=pre_process,
-                post_process=post_process
-            )
+            raise NotImplementedError("DeepSpeed is required for T0")
+
     see_memory_usage(f"After Building Model", force=True)
     return model
-
 
 def get_batch_pipe_packed(data):
     """
@@ -72,10 +68,6 @@ def get_batch_pipe_packed(data):
     data_b = mpu.broadcast_data(keys, data, datatype)
 
     # Unpack.
-    tokens_ = data_b['text'].long()
-    labels = tokens_[:, 1:].contiguous()
-    tokens = tokens_[:, :-1].contiguous()
-
     tokens_ = data_b['decoder_target_tokens'].long()
     labels = tokens_[:, 1:].contiguous()
     tokens = tokens_[:, :-1].contiguous()
@@ -127,37 +119,20 @@ def loss_func(loss_mask, output_tensor):
     return loss, {'lm loss': averaged_loss[0]}
 
 
-def forward_step(data_iterator, model):
-    """Forward step."""
-    args = get_args()
-    timers = get_timers()
-
-    # Get the batch.
-    timers('batch-generator').start()
-    tokens, labels, loss_mask, attention_mask, position_ids = get_batch(
-        data_iterator)
-    timers('batch-generator').stop()
-
-    output_tensor = model(tokens, position_ids, attention_mask,
-                          labels=labels)
-    if args.curriculum_learning and args.curriculum_seqlen < args.seq_length:
-        loss_mask = loss_mask[:, :args.curriculum_seqlen].contiguous()
-
-    return output_tensor, partial(loss_func, loss_mask)
-
-
 def train_valid_test_datasets_provider(train_val_test_num_samples):
     """Build train, valid, and test datasets."""
     args = get_args()
     train_ds, valid_ds, test_ds = None, None, None
 
-    print_rank_0('> building train, validation, and test datasets for GPT ...')
+    print_rank_0('> building train, validation, and test datasets for T0 ...')
     # Option 1 of data loading using --data-path
-
+    # For T0, data has to be provided in the form --data-path input-data target-data input-data2 target-data2 ...
     if args.data_path:
 
-        import json
-        data_path_dict = [json.loads(args.data_path)]
+        # Turn into list of pairs; Overwrite args.data_path to keep len = 1
+        # TODO: Not yet compatible with dataset weights (Will break at prefixes, weights = analyze_data_prefix(args.data_path))
+        assert len(args.data_path) > 1, "Please provide data in pairs of two: input_tokens target_tokens"
+        args.data_path = [{"input_tokens": args.data_path[i], "target_tokens": args.data_path[i+1]} for i in range(0, len(args.data_path), 2)]
 
         train_ds, valid_ds, test_ds = build_train_valid_test_datasets(
             data_prefix=args.data_path,
@@ -167,33 +142,6 @@ def train_valid_test_datasets_provider(train_val_test_num_samples):
             seq_length=args.seq_length,
             seed=args.seed,
             skip_warmup=(not args.mmap_warmup))
-
-    # # Option 2 of data loading using --(train|valid|test)-weighted-split-paths
-    # elif args.train_weighted_split_paths:
-    #     assigned_train_valid_test = []
-    #     if args.train_weighted_split_paths is not None:
-    #         train_ds = []
-    #         assigned_train_valid_test.append("train")
-    #     if args.valid_weighted_split_paths is not None:
-    #         valid_ds = []
-    #         assigned_train_valid_test.append("valid")
-    #     if args.test_weighted_split_paths is not None:
-    #         test_ds = []
-    #         assigned_train_valid_test.append("test")
-
-    #     for s in assigned_train_valid_test:
-    #         data_groups = zip(eval(f"args.{s}_weighted_split_paths"),
-    #                             eval(f"args.{s}_weighted_split_weights"),
-    #                             eval(f"args.{s}_weighted_split_splits"),
-    #                             eval(f"args.{s}_weighted_split_names"))
-    #         for paths, weights, splits, name in data_groups:
-    #             d = build_dataset_group(name, paths, weights, splits,
-    #                                     args.data_impl,
-    #                                     train_val_test_num_samples,
-    #                                     args.seq_length, args.seed,
-    #                                     (not args.mmap_warmup),
-    #                                     train_valid_test=s)
-    #             eval(f"{s}_ds").append(d)
     else:
         raise NotImplementedError("No dataloading argument passed")
 
@@ -202,8 +150,10 @@ def train_valid_test_datasets_provider(train_val_test_num_samples):
 
 @record
 def main():
-    pretrain(train_valid_test_datasets_provider, model_provider, forward_step,
-             args_defaults={'tokenizer_type': 'GPT2BPETokenizer'})
+    pretrain(train_valid_test_datasets_provider, 
+            model_provider, 
+            forward_step_func=None,
+            args_defaults={'tokenizer_type': 'GPT2BPETokenizer'})
 
 if __name__ == "__main__":
     main()

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -553,7 +553,7 @@ def _add_training_args(parser):
                        'please refer https://github.com/facebookresearch/bitsandbytes.',
                        dest='use_bnb_optimizer')
     group.add_argument('--dataloader-type', type=str, default=None,
-                       choices=['single', 'cyclic'],
+                       choices=['single', 'cyclic', 'packed'],
                        help='Single pass vs multiple pass data loader')
     group.add_argument('--cpu-optimizer', action='store_true',
                        help='Run optimizer on CPU')

--- a/megatron/data/data_samplers.py
+++ b/megatron/data/data_samplers.py
@@ -76,10 +76,11 @@ def pack_samples(items, max_seq_len=2049):
         decoder_segment_ids[batch_num].append(np.zeros((len_diff)))
         decoder_causal_attention[batch_num].append(np.zeros((len_diff)))
 
+    # Normally the default collate_fn handles torch tensor conversion; As we use a custom collate_fn, do it here
     return {
-        "decoder_target_tokens": np.stack([np.concatenate(arr) for arr in decoder_target_tokens]),
-        "decoder_segment_ids": np.stack([np.concatenate(arr) for arr in decoder_segment_ids]),
-        "decoder_causal_attention": np.stack([np.concatenate(arr) for arr in decoder_causal_attention]),
+        "decoder_target_tokens": torch.as_tensor(np.stack([np.concatenate(arr) for arr in decoder_target_tokens]), dtype=torch.int64),
+        "decoder_segment_ids": torch.as_tensor(np.stack([np.concatenate(arr) for arr in decoder_segment_ids]), dtype=torch.int64),
+        "decoder_causal_attention": torch.as_tensor(np.stack([np.concatenate(arr) for arr in decoder_causal_attention]), dtype=torch.int64),
     }
 
 

--- a/megatron/data/non_causal_mtf_dataset.py
+++ b/megatron/data/non_causal_mtf_dataset.py
@@ -172,7 +172,7 @@ def _build_train_valid_test_datasets(data_prefix, data_impl, splits_string,
     """Build train, valid, and test datasets."""
 
 
-    # Indexed dataset.
+    # Indexed dataset - Create seperate dataset for all fields (input & target tokens)
     indexed_dataset = {}
     for field in data_prefix:
         indexed_dataset[field] = get_indexed_dataset_(data_prefix[field], data_impl, skip_warmup)
@@ -283,6 +283,7 @@ def _build_index_mappings(name, data_prefix, documents, sizes,
     # Number of tokens in each epoch and number of required epochs.
     tokens_per_epoch = _num_tokens(documents, sizes)
     num_epochs = _num_epochs(tokens_per_epoch, seq_length, num_samples)
+
     # rng state
     np_rng = np.random.RandomState(seed=seed)
 

--- a/megatron/training.py
+++ b/megatron/training.py
@@ -1174,7 +1174,7 @@ def build_train_valid_test_data_iterators(
 
     # Build iterators.
     dl_type = args.dataloader_type
-    assert dl_type in ['single', 'cyclic']
+    assert dl_type in ['single', 'cyclic', 'packed']
 
     if train_dataloader is not None:
         train_data_iterator = iter(train_dataloader) if dl_type == 'single' \


### PR DESCRIPTION
See below for a slurm script with which training worked for me 🤗


```bash
#!/bin/bash
#SBATCH --job-name=tr11e-350M-ml-t0
#SBATCH --qos=qos_gpu-t3
#SBATCH --nodes=8
#SBATCH --ntasks-per-node=1          # crucial - only 1 task per dist per node!
#SBATCH --cpus-per-task=40           # number of cores per tasks
#SBATCH --hint=nomultithread         # we get physical cores not logical
#SBATCH --gres=gpu:4                 # number of gpus
#SBATCH -C v100-32g
#SBATCH --time 20:00:00             # maximum execution time (HH:MM:SS)
#SBATCH --output=%x-%j.out           # output file name
#SBATCH --account=six@v100

set -x -e

source $six_ALL_CCFRWORK/start-muennighofflmeval
echo "START TIME: $(date)"

variant=main

DATA_OUTPUT_PATH=$six_ALL_CCFRSCRATCH/checkpoints/tr11e-350M-ml
CHECKPOINT_PATH=$DATA_OUTPUT_PATH/checkpoints/$variant
REPO_PATH=$DATA_OUTPUT_PATH/tr11e-350M-ml-logs
TENSORBOARD_PATH=$REPO_PATH/tensorboard-test/$variant
LOGS_PATH=$REPO_PATH/logs-test/$variant
mkdir -p $LOGS_PATH

MEGATRON_DEEPSPEED_REPO=/gpfsscratch/rech/six/commun/commun/experiments/muennighoff/megdsmtf/muennighoff/Megatron-DeepSpeed
cd $MEGATRON_DEEPSPEED_REPO

BIGSCIENCE_REPO=$six_ALL_CCFRWORK/code/bigscience
TOKENIZER_NAME_OR_PATH=bigscience-catalogue-data-dev/byte-level-bpe-tokenizer-no-norm-250k-whitespace-and-eos-regex-alpha-v3-dedup-lines-articles

# defining the right environment variables
export TRANSFORMERS_CACHE=$six_ALL_CCFRWORK/models
export HF_DATASETS_CACHE=$six_ALL_CCFRWORK/datasets
export HF_MODULES_CACHE=$six_ALL_CCFRWORK/modules
export HF_METRICS_CACHE=$six_ALL_CCFRWORK/metrics
export HF_DATASETS_OFFLINE=1
export TRANSFORMERS_OFFLINE=1

# testing for potential faulty nodes
# srun --jobid $SLURM_JOBID bash -c 'python -c "import torch, socket; print(socket.gethostname(), torch.cuda.is_available())"'

# so processes know who to talk to
MASTER_ADDR=$(scontrol show hostnames $SLURM_JOB_NODELIST | head -n 1)
MASTER_PORT=6001

GPUS_PER_NODE=1
NNODES=1

PP_SIZE=1
TP_SIZE=1

MICRO_BATCH_SIZE=1
GLOBAL_BATCH_SIZE=4

NLAYERS=2
NHIDDEN=1024
NHEADS=16
SEQ_LEN=256

SAVE_INTERVAL=250

TRAIN_SAMPLES=10  # TODO
LR_DECAY_SAMPLES=10  # TODO
LR_WARMUP_SAMPLES=1  # TODO


OPTIMIZER_ARGS=" \
    --optimizer adam \
    --adam-beta1 0.9 \
    --adam-beta2 0.95 \
    --adam-eps 1e-8 \
    --lr 3.0e-4 \
    --min-lr 1e-5 \
    --lr-decay-style cosine \
    --lr-decay-samples $LR_DECAY_SAMPLES \
    --lr-warmup-samples $LR_WARMUP_SAMPLES \
    --clip-grad 1.0 \
    --weight-decay 1e-1 \
    "
# for 20h 1190, for 100h 5990
#    --exit-duration-in-mins 1190 \
EXIT_OPTS=" \
    --exit-duration-in-mins 5990 \
    "

GPT_ARGS=" \
    --pp-partition-method 'type:transformer|embedding' \
    --num-layers $NLAYERS \
    --hidden-size $NHIDDEN \
    --num-attention-heads $NHEADS \
    --seq-length $SEQ_LEN \
    --max-position-embeddings $SEQ_LEN \
    --micro-batch-size $MICRO_BATCH_SIZE \
    --global-batch-size $GLOBAL_BATCH_SIZE \
    --train-samples $TRAIN_SAMPLES \
    --tokenizer-type PretrainedFromHF \
    --tokenizer-name-or-path $TOKENIZER_NAME_OR_PATH \
    --init-method-std 0.0048 \
    --embed-layernorm \
    --fp16 \
    --seed 42 \
    --position-embedding-type alibi \
    --abort-on-unmet-fused-kernel-constraints \
    --pad-vocab-size-to 250880 \
    $OPTIMIZER_ARGS \
    $EXIT_OPTS \
    "

OUTPUT_ARGS=" \
    --log-interval 1 \
    --save-interval $SAVE_INTERVAL \
    --eval-interval 1000 \
    --eval-iters 1 \
    --tensorboard-dir $TENSORBOARD_PATH \
    --tensorboard-queue-size 5 \
    --log-timers-to-tensorboard \
    --log-batch-size-to-tensorboard \
    --log-validation-ppl-to-tensorboard \
    "

ZERO_STAGE=0 # important: bf16 must use z0! it implements its own zero stage 1 equivalent

config_json="./ds_config.$SLURM_JOBID.json"

# Deepspeed figures out GAS dynamically from dynamic GBS via set_train_batch_size()
cat <<EOT > $config_json
{
  "train_micro_batch_size_per_gpu": $MICRO_BATCH_SIZE,
  "train_batch_size": $GLOBAL_BATCH_SIZE,
  "gradient_clipping": 1.0,
  "zero_optimization": {
    "stage": $ZERO_STAGE
  },
  "fp16": {
    "enabled": true,
    "loss_scale": 0,
    "loss_scale_window": 500,
    "hysteresis": 2,
    "min_loss_scale": 1,
    "initial_scale_power": 12
  },
  "steps_per_print": 2000,
  "wall_clock_breakdown": false
}
EOT


DEEPSPEED_ARGS=" \
    --deepspeed \
    --deepspeed_config ${config_json} \
    --zero-stage ${ZERO_STAGE} \
    --deepspeed-activation-checkpointing \
    "

export LAUNCHER="python -u -m torch.distributed.run \
    --nproc_per_node $GPUS_PER_NODE \
    --nnodes $NNODES \
    --rdzv_endpoint $MASTER_ADDR:$MASTER_PORT \
    --rdzv_backend c10d \
    --max_restarts 0 \
    --tee 3 \
    "

DATA_PATH="tests/data/t0/ag_news_prompt_inputs_document tests/data/t0/ag_news_prompt_targets_document"

export CMD=" \
    `pwd`/finetune_t0.py \
    --tensor-model-parallel-size $TP_SIZE \
    --pipeline-model-parallel-size $PP_SIZE \
    $GPT_ARGS \
    $OUTPUT_ARGS \
    --data-path $DATA_PATH \
    --split 100,0,0 \
    --dataloader-type packed \
    --data-impl mmap \
    --distributed-backend nccl \
     $DEEPSPEED_ARGS \
    "

echo $CMD

# do not remove or the training will hang and nodes will be lost w/o this workaround
export CUDA_LAUNCH_BLOCKING=1

# hide duplicated errors using this hack - will be properly fixed in pt-1.12
export TORCHELASTIC_ERROR_FILE=/tmp/torch-elastic-error.json

clear; srun --jobid $SLURM_JOBID bash -c "$LAUNCHER --node_rank \$SLURM_PROCID $CMD" 2>&1 | tee -a $LOGS_PATH/main_log.txt

echo "END TIME: $(date)"

```